### PR TITLE
DEV-23290 : Fixed extra footer space issue

### DIFF
--- a/src/android/CDVIonicKeyboard.java
+++ b/src/android/CDVIonicKeyboard.java
@@ -202,22 +202,6 @@ public class CDVIonicKeyboard extends CordovaPlugin {
         return false;  // Returning false results in a "MethodNotFound" error.
     }
 
-    private int getWebViewVersion() {
-        try {
-            PackageInfo pkg = WebView.getCurrentWebViewPackage();
-            if (pkg == null || pkg.versionName == null) {
-                Timber.w("WebView package/version unavailable");
-                return 0;
-            }
-            Timber.d("WebView → Version: %s, Code: %d, Package: %s",
-                pkg.versionName, pkg.versionCode, pkg.packageName);
-            return Integer.parseInt(pkg.versionName.split("\\.")[0]);
-        } catch (Exception e) {
-            Timber.e(e, "Failed to read WebView version");
-            return 0; // safe fallback
-        }
-    }
-
     @Override
     public void onDestroy() {
         rootView.getViewTreeObserver().removeOnGlobalLayoutListener(list);


### PR DESCRIPTION
 This fix deals with how Android system window insets (status bar, navigation bar, gesture area) are applied to the app’s root view. With the updated review 144 and android target 35, we observed increased space beneath footer. Fixed footer layout issue and other truncation observations reported.